### PR TITLE
Remove qwsx from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Add a website by reading [CONTRIBUTING.md](CONTRIBUTING.md)
   - [Gnovies](http://www.gnovies.com/) - Discovering movies
   - [Gnod Art](http://art.gnod.com/) - Discovering artists
 - [10kb Gallery](https://10kb.neocities.org/about.html) -  art within 10,000 bytes
-- [qwsx](https://qwsx.cf/) - URL Shortener
 - [emuparadise](https://www.emuparadise.me/) - Place to download and play old-school retro video games
 - [tucktools](https://www.tucktools.com/) - Free online tools - Needs JavaScript to work
 - [privado](https://www.privado.com/) - A lightweight search engine that doesn't IP address or searches in any identifiable way


### PR DESCRIPTION
I've removed qwsx from the 'Other' list since the link no longer works - it currently leads to an expired domain page.